### PR TITLE
CloudForms update

### DIFF
--- a/python/ansible_tower_cloudforms_inventory.py
+++ b/python/ansible_tower_cloudforms_inventory.py
@@ -13,7 +13,6 @@ import argparse
 import ConfigParser
 import requests
 import json
-import warnings
 
 
 class CloudFormsInventory(object):
@@ -143,3 +142,4 @@ class CloudFormsInventory(object):
 
 # Run the script
 CloudFormsInventory()
+

--- a/python/ansible_tower_cloudforms_inventory.py
+++ b/python/ansible_tower_cloudforms_inventory.py
@@ -60,7 +60,7 @@ class CloudFormsInventory(object):
         config = ConfigParser.SafeConfigParser()
         config_paths = [
             os.path.join(os.path.dirname(os.path.realpath(__file__)), 'cloudforms.ini'),
-            "/opt/rh/cloudforms.ini",
+            "/etc/ansible/cloudforms.ini",
         ]
 
         env_value = os.environ.get('CLOUDFORMS_INI_PATH')

--- a/python/ansible_tower_cloudforms_inventory.py
+++ b/python/ansible_tower_cloudforms_inventory.py
@@ -93,6 +93,12 @@ class CloudFormsInventory(object):
         else:
             self.cloudforms_password = "none"
 
+        # CloudForms Password
+        if config.has_option('cloudforms', 'ssl_verify'):
+            self.cloudforms_ssl_verify = config.getboolean('cloudforms', 'ssl_verify')
+        else:
+            self.cloudforms_ssl_verify = False
+
     def get_hosts(self):
         ''' Gets host from CloudForms '''
         with warnings.catch_warnings():

--- a/python/cloudforms.ini
+++ b/python/cloudforms.ini
@@ -4,7 +4,7 @@
 [cloudforms]
 
 # The version of CloudForms (this is not used yet)
-version = 3.1
+version = 4.1
 
 # The hostname of the CloudForms server
 hostname = #insert your hostname here
@@ -13,4 +13,7 @@ hostname = #insert your hostname here
 username = #insert your cloudforms user here
 
 # Password for CloudForms user
-password = #password 
+password = #password
+
+# Verify SSL certificates (I know you want to be secure, RIGHT?!)
+ssl_verify = True


### PR DESCRIPTION
Not sure if this is the ideal place for this pull request, but I could not get CloudForms integration to work with Tower 3.0.1 and CloudForms 4.1...  e-mail me if you want a sidebar: jpreston@redhat.com

A few changes... I rewrote the get_hosts method substantially to return a more sane and correct inventory.  I had an issue where the name assigned to the VM in CloudForms was nowhere near a valid hostname.  Now, I want to use the IP address and include _meta for the 'name' value.  Also, I now sort the output...

I also pull in the tags that CloudForms uses and create groups for them.  I'll rework the get_hosts when I get a chance and submit separately.

Thanks!

Output now looks like:

```
{
  "/managed/folder_path_blue/datacenters:default:vm": [
    "192.168.0.241", 
    "192.168.0.242", 
    "192.168.0.243", 
    "192.168.0.21", 
    "192.168.0.244", 
    "192.168.0.245"
  ], 
  "/managed/folder_path_yellow/datacenters": [
    "192.168.0.241", 
    "192.168.0.242", 
    "192.168.0.243", 
    "192.168.0.21", 
    "192.168.0.244", 
    "192.168.0.245"
  ], 
  "_meta": {
    "hostvars": {
      "192.168.0.21": {
        "cloud": false, 
        "connection_state": "connected", 
        "created_on": "2016-08-03T14:06:20Z", 
        "host_id": 614000000000001, 
        "id": 614000000000580, 
        "name": "fedora-workstation", 
        "power_state": "on", 
        "raw_power_state": "up", 
        "template": false, 
        "type": "ManageIQ::Providers::Redhat::InfraManager::Vm", 
        "vendor": "redhat"
      }, 
      "192.168.0.241": {
        "cloud": false, 
        "connection_state": "connected", 
        "created_on": "2016-08-02T00:31:15Z", 
        "host_id": 614000000000001, 
        "id": 614000000000002, 
        "name": "HostedEngine", 
        "power_state": "on", 
        "raw_power_state": "up", 
        "template": false, 
        "type": "ManageIQ::Providers::Redhat::InfraManager::Vm", 
        "vendor": "redhat"
      }, 
      "192.168.0.242": {
        "cloud": false, 
        "connection_state": "connected", 
        "created_on": "2016-08-02T00:31:15Z", 
        "host_id": 614000000000001, 
        "id": 614000000000001, 
        "name": "cfme", 
        "power_state": "on", 
        "raw_power_state": "up", 
        "template": false, 
        "type": "ManageIQ::Providers::Redhat::InfraManager::Vm", 
        "vendor": "redhat"
      }, 
      "192.168.0.243": {
        "cloud": false, 
        "connection_state": "connected", 
        "created_on": "2016-08-02T01:46:10Z", 
        "host_id": 614000000000001, 
        "id": 614000000000576, 
        "name": "tower", 
        "power_state": "on", 
        "raw_power_state": "up", 
        "template": false, 
        "type": "ManageIQ::Providers::Redhat::InfraManager::Vm", 
        "vendor": "redhat"
      }, 
      "192.168.0.244": {
        "cloud": false, 
        "connection_state": "connected", 
        "created_on": "2016-08-03T17:50:40Z", 
        "host_id": 614000000000001, 
        "id": 614000000000582, 
        "name": "idm", 
        "power_state": "on", 
        "raw_power_state": "up", 
        "template": false, 
        "type": "ManageIQ::Providers::Redhat::InfraManager::Vm", 
        "vendor": "redhat"
      }, 
      "192.168.0.245": {
        "cloud": false, 
        "connection_state": "connected", 
        "created_on": "2016-08-05T14:48:08Z", 
        "host_id": 614000000000001, 
        "id": 614000000000591, 
        "name": "satellite", 
        "power_state": "on", 
        "raw_power_state": "up", 
        "template": false, 
        "type": "ManageIQ::Providers::Redhat::InfraManager::Vm", 
        "vendor": "redhat"
      }
    }
  }, 
  "cloudforms": {
    "hosts": [
      "192.168.0.241", 
      "192.168.0.242", 
      "192.168.0.243", 
      "192.168.0.21", 
      "192.168.0.244", 
      "192.168.0.245"
    ]
  }
}
```
